### PR TITLE
Fixes #18: Delay disablement of `WSAIFabricSvc` service

### DIFF
--- a/isoDebloaterScript.ps1
+++ b/isoDebloaterScript.ps1
@@ -948,8 +948,9 @@ if ($buildNumber -ge 22000) {
             reg add "HKLM\zSOFTWARE\Policies\Microsoft\Edge" /v "CopilotCDPPageContext" /t REG_DWORD /d "0" /f 2>&1 | Write-Log
             # Disable AI in Search
             reg add "HKLM\zSOFTWARE\Policies\Microsoft\Windows\WindowsAI" /v "DisableClickToDo" /t REG_DWORD /d "1" /f 2>&1 | Write-Log
-            # Disable WSAIFabricSvc Service
-            reg add "HKLM\zSYSTEM\CurrentControlSet\Services\WSAIFabricSvc" /v "Start" /t REG_DWORD /d "4" /f 2>&1 | Write-Log
+            # Disable WSAIFabricSvc Service on first logon
+            reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce" /v "DisableWSAIFabricSvc" /t REG_SZ /d 'reg add "HKLM\SYSTEM\CurrentControlSet\Services\WSAIFabricSvc" /v "Start" /t REG_DWORD /d "4" /f'
+            reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce" /v "StopWSAIFabricSvc" /t REG_SZ /d "net stop WSAIFabricSvc"
             # Hide AI components from Settings
             reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "SettingsPageVisibility" /t REG_SZ /d "hide:aicomponents" /f 2>&1 | Write-Log
             # Disable AI from Explorer


### PR DESCRIPTION
As mentioned in #18, the most recent version of `Windows-ISO-Debloater` causes a `CONFIG_INITIALIZATION_ERROR (0x67)` when installing Windows 11.

Changes made in this commit adjust the code to disable the `WSAIFabricSvc` after the first logon instead of having it disabled initially.

The debloater script has been tested with:
  * Windows 11
    * The version mentioned in the `README.md` file (Build 26100.1742)
    * The most recent version available on Microsoft's official website and Massgrave (Build 26200.7632)
  * Windows 10
    * The version most similar to the one mentioned in the `README.md` file (Build 19045.4894)

All patches worked flawlessly with this PR.

Merging this PR will fix #18.